### PR TITLE
The ' must be escaped in the "generated" code, otherwise syntax error.

### DIFF
--- a/lib/skpm-init.js
+++ b/lib/skpm-init.js
@@ -45,7 +45,7 @@ Promise.resolve()
   fs.mkdirSync(path.join(process.cwd(), packageJSON.main))
   fs.mkdirSync(path.join(process.cwd(), 'src'))
   fs.writeFileSync(path.join(process.cwd(), 'src', 'manifest.json'), JSON.stringify(require('./getManifest')(packageJSON.name), null, '\t'))
-  fs.writeFileSync(path.join(process.cwd(), 'src', 'my-command.js'), 'export default function (context) {\n  context.document.showMessage(\'It\'s alive 🙌\\\')\n}\n')
+  fs.writeFileSync(path.join(process.cwd(), 'src', 'my-command.js'), 'export default function (context) {\n  context.document.showMessage(\'It\\\'s alive 🙌\\\')\n}\n')
   return packageJSON
 })
 .then(function (packageJSON) {


### PR DESCRIPTION
Fixes an issue with the plugin generated from 'skpm init'