### PR TITLE
Fix typo in my-command.js

### DIFF
--- a/lib/skpm-init.js
+++ b/lib/skpm-init.js
@@ -45,7 +45,7 @@ Promise.resolve()
   fs.mkdirSync(path.join(process.cwd(), packageJSON.main))
   fs.mkdirSync(path.join(process.cwd(), 'src'))
   fs.writeFileSync(path.join(process.cwd(), 'src', 'manifest.json'), JSON.stringify(require('./getManifest')(packageJSON.name), null, '\t'))
-  fs.writeFileSync(path.join(process.cwd(), 'src', 'my-command.js'), 'export default function (context) {\n  context.document.showMessage(\'It\\\'s alive 🙌\\\')\n}\n')
+  fs.writeFileSync(path.join(process.cwd(), 'src', 'my-command.js'), 'export default function (context) {\n  context.document.showMessage(\'It\\\'s alive 🙌\')\n}\n')
   return packageJSON
 })
 .then(function (packageJSON) {


### PR DESCRIPTION
I think you're escaping too many times — it's rendering out as
```js
context.document.showMessage('It\'s alive🙌\')
```
and giving an 'unterminated string constant' error