### PR TITLE
Updated README to reflect the --watch option. Closes #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ To transpile the JavaScript to CocoaScript and copy the `manifest.json` to the `
 skpm build
 ```
 
+To watch for changes:
+
+```bash
+skpm build --watch
+```
+
 Additionally, some fields from the `package.json` will be set in the `manifest.json` (if not present):
 * version
 * name
@@ -80,15 +86,6 @@ skpm link path-to-local-plugin
 ```
 
 It will also ask you if you want to [disable the caching mechanism](http://developer.sketchapp.com/introduction/preferences/#always-reload-scripts-before-running) and force Sketch to always reload a Plugin’s code from disk (recommended when developing).
-
-
-#### Watching for changes
-
-To automatically rebuild and link your plugin as you make changes:
-
-```bash
-skpm build --watch
-```
 
 #### Publish the plugin on the registry
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ skpm link path-to-local-plugin
 
 It will also ask you if you want to [disable the caching mechanism](http://developer.sketchapp.com/introduction/preferences/#always-reload-scripts-before-running) and force Sketch to always reload a Plugin’s code from disk (recommended when developing).
 
+
+#### Watching for changes
+
+To automatically rebuild and link your plugin as you make changes:
+
+```bash
+skpm build --watch
+```
+
 #### Publish the plugin on the registry
 
 To publish a new version of the plugin to the registry:


### PR DESCRIPTION
I've updated the README to reflect the `--watch` build option.

I put it after the "Linking" section in the docs since `watch` involves both the `build` and `link` command. I could definitely see an argument for putting it right under the Build section.

Please let me know if you've got any feedback.