### PR TITLE
Generating a clearer error message when a plugin has already been linked

### DIFF
--- a/lib/skpm-link.js
+++ b/lib/skpm-link.js
@@ -72,9 +72,11 @@ if (!packageJSON.name) {
 console.log(chalk.dim('[1/1]') + ' 🔗  Symlinking the plugin ' + packageJSON.name + '...')
 
 try {
-  if (!fs.existsSync(path.join(pluginDirectory, packageJSON.name))) {
-    fs.mkdirSync(path.join(pluginDirectory, packageJSON.name))
+  if (fs.existsSync(path.join(pluginDirectory, packageJSON.name))) {
+    return console.log(chalk.red('error') + ' This plugin has already been linked.')
   }
+
+  fs.mkdirSync(path.join(pluginDirectory, packageJSON.name))
   fs.symlinkSync(getPath(packageJSON.main), path.join(pluginDirectory, packageJSON.name, packageJSON.main))
 
   testDevMode(function () {

--- a/lib/skpm-link.js
+++ b/lib/skpm-link.js
@@ -72,11 +72,17 @@ if (!packageJSON.name) {
 console.log(chalk.dim('[1/1]') + ' 🔗  Symlinking the plugin ' + packageJSON.name + '...')
 
 try {
-  if (fs.existsSync(path.join(pluginDirectory, packageJSON.name))) {
+  // Create the encompassing directory if it doesn't already exist
+  if (!fs.existsSync(path.join(pluginDirectory, packageJSON.name))) {
+    fs.mkdirSync(path.join(pluginDirectory, packageJSON.name))
+  }
+
+  // Show an error if this symlink already exists
+  if (fs.existsSync(path.join(pluginDirectory, packageJSON.name, packageJSON.main))) {
     return console.log(chalk.red('error') + ' This plugin has already been linked.')
   }
 
-  fs.mkdirSync(path.join(pluginDirectory, packageJSON.name))
+  // Create the symlink within the encompassing directory
   fs.symlinkSync(getPath(packageJSON.main), path.join(pluginDirectory, packageJSON.name, packageJSON.main))
 
   testDevMode(function () {


### PR DESCRIPTION
Currently if you run `skpm link` when the project has already been linked, it outputs the following rather ugly error:

```
$ skpm link
[1/1] 🔗  Symlinking the plugin l10n-sketch-plugin...
error Error while symlinking the plugin l10n-sketch-plugin
{ Error: EEXIST: file already exists, symlink '/Users/USER/Development/l10n-sketch-plugin/plugin.sketchplugin' -> '/Users/USER/Library/Application Support/com.bohemiancoding.sketch3/Plugins/l10n-sketch-plugin/plugin.sketchplugin'
    at Error (native)
    at Object.fs.symlinkSync (fs.js:1054:18)
    at Object.<anonymous> (/Users/USER/Development/skpm/lib/skpm-link.js:78:6)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
  errno: -17,
  code: 'EEXIST',
  syscall: 'symlink',
  path: '/Users/USER/Development/l10n-sketch-plugin/plugin.sketchplugin',
  dest: '/Users/USER/Library/Application Support/com.bohemiancoding.sketch3/Plugins/l10n-sketch-plugin/plugin.sketchplugin' }
```

I propose a simpler output:

```
$ skpm link
[1/1] 🔗  Symlinking the plugin l10n-sketch-plugin...
error This plugin has already been linked.
```

Any thoughts for or against this change?