### PR TITLE
Tweaks to webpack config

### DIFF
--- a/lib/skpm-build.js
+++ b/lib/skpm-build.js
@@ -111,7 +111,10 @@ function webpackConfig (file, isCommand) {
           raw: true,
           entryOnly: true
         }) : []
-      )
+      ),
+      resolve: {
+        extensions: ['.sketch.js', '.js']
+      }
     }
   )
 }

--- a/lib/skpm-build.js
+++ b/lib/skpm-build.js
@@ -87,7 +87,8 @@ function webpackConfig (file, isCommand) {
             use: {
               loader: 'babel-loader',
               options: {
-                plugins: [require('babel-plugin-add-module-exports')]
+                plugins: [require('babel-plugin-add-module-exports')],
+                presets: ['airbnb']
               }
             }
           }

--- a/lib/skpm-build.js
+++ b/lib/skpm-build.js
@@ -56,6 +56,7 @@ try {
 } catch (err) {
   console.error(chalk.red('error') + ' Error while reading webpack.config.js')
   console.error(err)
+  process.exit(1)
 }
 
 if (!fs.existsSync(output)) {

--- a/lib/skpm-build.js
+++ b/lib/skpm-build.js
@@ -114,7 +114,7 @@ function webpackConfig (file, isCommand, identifier) {
               loader: 'babel-loader',
               options: {
                 plugins: [require('babel-plugin-add-module-exports')],
-                presets: ['airbnb']
+                presets: [require('babel-preset-airbnb')]
               }
             }
           }

--- a/lib/skpm-build.js
+++ b/lib/skpm-build.js
@@ -6,6 +6,7 @@ var program = require('commander')
 var chalk = require('chalk')
 var uniqBy = require('lodash.uniqby')
 var objectAssign = require('object-assign')
+var WebpackShellPlugin = require('webpack-shell-plugin')
 
 var buildEmojis = ['🔧', '🔨', '⚒', '🛠', '⛏', '🔩']
 function randomBuildEmoji () {
@@ -17,6 +18,7 @@ program
   .usage('[options]')
   .option('-w, --watch', 'Watch and rebuild automatically')
   .option('-q, --quiet', 'Hide compilation warnings')
+  .option('-r, --run', 'Run plugin after compiling')
   .parse(process.argv)
 
 var packageJSON
@@ -75,8 +77,32 @@ var manifestFolder = path.dirname(manifest)
 
 var consolePolyfill = fs.readFileSync(require.resolve('./utils/consolePolyfill'), 'utf8')
 
-function webpackConfig (file, isCommand) {
+function webpackConfig (file, isCommand, identifier) {
   var basename = path.basename(file)
+
+  var plugins = userDefinedWebpackConfig.plugins || []
+
+  if (isCommand) {
+    plugins.push(
+      new webpack.BannerPlugin({
+        banner: consolePolyfill,
+        raw: true,
+        entryOnly: true
+      })
+    )
+  }
+
+  if (isCommand && program.run) {
+    plugins.push(
+      new WebpackShellPlugin({
+        onBuildEnd: [
+          '/Applications/Sketch.app/Contents/Resources/sketchtool/bin/sketchtool run ' + output + ' ' + identifier,
+        ],
+        dev: false,
+      })
+    )
+  }
+
   return objectAssign(
     {
       module: {
@@ -105,13 +131,7 @@ function webpackConfig (file, isCommand) {
           ? path.join(output, 'Contents', 'Sketch')
           : path.join(output, 'Contents', 'Resources')
       },
-      plugins: (userDefinedWebpackConfig.plugins || []).concat(
-        isCommand ? new webpack.BannerPlugin({
-          banner: consolePolyfill,
-          raw: true,
-          entryOnly: true
-        }) : []
-      ),
+      plugins: plugins,
       resolve: {
         extensions: ['.sketch.js', '.js']
       }
@@ -201,8 +221,9 @@ function buildCallback (file, watching) {
 
 commands.concat(packageJSON.resources || []).forEach(function (command) {
   var file = command.script || command
+  var identifier = command.identifier || 'main'
   var isCommand = command.script
-  const compiler = webpack(webpackConfig(file, isCommand))
+  const compiler = webpack(webpackConfig(file, isCommand, identifier))
   if (program.watch) {
     compiler.watch({}, buildCallback(file, program.watch))
   } else {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "adm-zip": "^0.4.7",
+    "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0-beta.1",
     "babel-plugin-add-module-exports": "^0.2.1",
     "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "skpm-client": "^0.2.0",
     "tar.gz": "^1.0.5",
     "webpack": "^2.3.3",
+    "webpack-shell-plugin": "^0.5.0",
     "yesno": "^0.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0-beta.1",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-preset-airbnb": "^2.2.3",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "cpr": "^2.0.2",


### PR DESCRIPTION
I added some things - each is in a commit so you can cherrypick / ignore as you want :)

- we should exit the process when the `webpack.config.js` can't be read, otherwise weird bugs happen
- 🙏  I added a babel preset - I think it's a pretty decent default, and I can't think of a good reason not to add it - makes setup for clients way easier (and is still overridable)
- added the resolve extensions for `.sketch.js` — this is mostly useful right now for react-primitives, but with webpack it doesn't require a plugin so no overhead - again this provides a ton of benefit for react-sketchapp users for no extra cost
- added `--run` to build - I think this is still useful for non-react-sketchapp users