### PR TITLE
fix babelrc gettin'

### DIFF
--- a/lib/skpm-build.js
+++ b/lib/skpm-build.js
@@ -93,21 +93,27 @@ var manifestFolder = path.dirname(manifest)
 var consolePolyfill = fs.readFileSync(require.resolve('./utils/consolePolyfill'), 'utf8')
 
 function babelLoader (userDefinedBabelConfig) {
-  var base = {
+  var options = {
+    babelrc: false,
+    plugins: [require('babel-plugin-add-module-exports')]
+  }
+
+  if (userDefinedBabelConfig) {
+    options = objectAssign(options, userDefinedBabelConfig)
+  } else {
+    options = objectAssign(options, {
+      presets: [require('babel-preset-airbnb')]
+    })
+  }
+
+  return {
     test: /\.jsx?$/,
     exclude: /node_modules/,
     use: {
       loader: 'babel-loader',
-      options: {
-        plugins: [require('babel-plugin-add-module-exports')]
-      }
+      options: options
     }
   }
-
-  if (!userDefinedBabelConfig) {
-    base.use.options.presets = [require('babel-preset-airbnb')]
-  }
-  return base
 }
 
 function webpackConfig (file, commandIdentifier) {


### PR DESCRIPTION
Found a bug with the new .babelrc parsing - if a `skpm` project _doesn't_ have a .babelrc _and_ a parent directory does, babel-loader tries to use the parent .babelrc file.

Similar issue in `create-react-app` https://github.com/facebookincubator/create-react-app/issues/233
Similar patch in `nwb` https://github.com/insin/nwb/blob/0457e1a9917507ba89787f1ec142c6c8e783f63b/src/createWebpackConfig.js#L134-L140

This patch sets `babelrc: false` and then manually extends the `babel-loader` config with the resolved user .babelrc / package.json/babel, if appropriate